### PR TITLE
fix CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GRACE platform configuration [![CircleCI](https://circleci.com/gh/GSA/grace-core.svg?style=svg)](https://circleci.com/gh/GSA/grace-core)
+# GRACE platform configuration [![CircleCI](https://circleci.com/gh/GSA/grace-core.svg?style=svg&circle-token=d0bdc1c9e646280312a4a8254f7c8d4698c8729f)]
 
 This repository contains the core Terraform configuration for the [GRACE](https://github.com/gsa/devsecops#readme) platform. This includes:
 


### PR DESCRIPTION
Extracted from #16.

Note the token is read-only on the build status only (see https://github.com/circleci/circleci-docs/issues/2325#issuecomment-388903283), so not a security vulnerability to include it here.