### PR TITLE
store budget limits in AWS Parameter Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,6 @@ For new tenants, or tenants that want an additional AWS account, create one or m
 After the paperwork is done:
 
 1. Change the value in [Parameter Store](https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1).
-1. Recreate the budget. _This is needed because of some buggy behavior around the budgets / budget notifications._
-
-    ```sh
-    cd terraform/master
-    terraform taint -module=<name>_budget aws_budgets_budget.budget
-    ```
-
 1. [Rerun the latest `master` branch build in CircleCI.](https://circleci.com/gh/GSA/workflows/grace-core/tree/master)
 
 ## Security compliance

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Also included: [an example of cross-VPC/account networking](terraform/networking
 
 Having been done once for the account, the following steps shouldn't need to be done again. Documenting here for reference.
 
+1. Install the dependencies.
+    * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
+    * [Terraform](https://www.terraform.io/)
 1. [Configure AWS](https://www.terraform.io/docs/providers/aws/#authentication) with credentials for the master AWS account locally.
 1. Bootstrap the account.
 
@@ -31,6 +34,12 @@ Having been done once for the account, the following steps shouldn't need to be 
 
     ```sh
     aws s3 cp <path/to/scp.json> s3://grace-config/service_control_policy.json
+    ```
+
+1. Create a Parameter Store parameter for the master account budget.
+
+    ```sh
+    aws ssm put-parameter --type String --name master-budget --value <budget>
     ```
 
 CircleCI will deploy changes to the environment going forward.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ CircleCI will deploy changes to the environment going forward.
 
 For new tenants, or tenants that want an additional AWS account, create one or more new AWS accounts by:
 
+1. Create a Parameter Store parameter in the master account, either [through the Console](https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1), or by running:
+
+    ```sh
+    aws ssm put-parameter --type String --name <name>-budget --value <budget>
+    ```
+
 1. **Tenant or DevSecOps team:** Add a `tenant_<name>.tf` file to [`terraform/master/`](terraform/master).
     * See [`tenant_tenant1.tf`](terraform/master/tenant_tenant1.tf) for an example.
     * The `name` and `email` for each `member_account` should be unique.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ For new tenants, or tenants that want an additional AWS account, create one or m
     * This needs to be done manually, while waiting for [Terraform support](https://github.com/terraform-providers/terraform-provider-aws/pull/4405)
     * Easiest to do so through [the Console](https://console.aws.amazon.com/organizations/home)
 
+## Adjusting a budget
+
+After the paperwork is done:
+
+1. Change the value in [Parameter Store](https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1).
+1. Recreate the budget. _This is needed because of some buggy behavior around the budgets / budget notifications._
+
+    ```sh
+    cd terraform/master
+    terraform taint -module=<name>_budget aws_budgets_budget.budget
+    ```
+
+1. [Rerun the latest `master` branch build in CircleCI.](https://circleci.com/gh/GSA/workflows/grace-core/tree/master)
+
 ## Security compliance
 
 **Component approval status:** in assessment

--- a/terraform/budget/main.tf
+++ b/terraform/budget/main.tf
@@ -1,3 +1,7 @@
+data "aws_ssm_parameter" "budget" {
+  name = "${var.name}-budget"
+}
+
 locals {
   # workaround for trying to do conditionals with maps, since LinkedAccount can't be specified with an empty list
   # https://github.com/hashicorp/terraform/issues/12453#issuecomment-378033384
@@ -13,7 +17,7 @@ locals {
 resource "aws_budgets_budget" "budget" {
   name         = "${var.name}-monthly"
   budget_type  = "COST"
-  limit_amount = "${var.budget_limit}"
+  limit_amount = "${data.aws_ssm_parameter.budget.value}"
   limit_unit   = "USD"
 
   # far in the future
@@ -44,12 +48,12 @@ resource "null_resource" "budget_notifications" {
 
   # when actual bill exceeds budget
   provisioner "local-exec" {
-    command = "${local.notification_cmd_prefix} NotificationType=ACTUAL,ComparisonOperator=GREATER_THAN,Threshold=${var.budget_limit},ThresholdType=ABSOLUTE_VALUE"
+    command = "${local.notification_cmd_prefix} NotificationType=ACTUAL,ComparisonOperator=GREATER_THAN,Threshold=${data.aws_ssm_parameter.budget.value},ThresholdType=ABSOLUTE_VALUE"
   }
 
   # when forecasted bill exceeds budget
   provisioner "local-exec" {
-    command = "${local.notification_cmd_prefix} NotificationType=FORECASTED,ComparisonOperator=GREATER_THAN,Threshold=${var.budget_limit},ThresholdType=ABSOLUTE_VALUE"
+    command = "${local.notification_cmd_prefix} NotificationType=FORECASTED,ComparisonOperator=GREATER_THAN,Threshold=${data.aws_ssm_parameter.budget.value},ThresholdType=ABSOLUTE_VALUE"
   }
 }
 

--- a/terraform/budget/main.tf
+++ b/terraform/budget/main.tf
@@ -40,20 +40,15 @@ aws budgets create-notification \
 EOF
 }
 
-resource "null_resource" "budget_notifications" {
+# when forecasted bill exceeds budget
+resource "null_resource" "budget_forecast_notification" {
   triggers {
     budget_id = "${aws_budgets_budget.budget.id}"
     prefix    = "${local.notification_cmd_prefix}"
   }
 
-  # when actual bill exceeds budget
   provisioner "local-exec" {
-    command = "${local.notification_cmd_prefix} NotificationType=ACTUAL,ComparisonOperator=GREATER_THAN,Threshold=${data.aws_ssm_parameter.budget.value},ThresholdType=ABSOLUTE_VALUE"
-  }
-
-  # when forecasted bill exceeds budget
-  provisioner "local-exec" {
-    command = "${local.notification_cmd_prefix} NotificationType=FORECASTED,ComparisonOperator=GREATER_THAN,Threshold=${data.aws_ssm_parameter.budget.value},ThresholdType=ABSOLUTE_VALUE"
+    command = "${local.notification_cmd_prefix} NotificationType=FORECASTED,ComparisonOperator=GREATER_THAN,Threshold=100,ThresholdType=PERCENTAGE"
   }
 }
 

--- a/terraform/budget/variables.tf
+++ b/terraform/budget/variables.tf
@@ -7,11 +7,6 @@ variable "name" {
   type = "string"
 }
 
-variable "budget_limit" {
-  type        = "string"
-  description = "Budget limit, as an integer"
-}
-
 variable "budget_notifications" {
   default     = []
   description = "A list of where to send notifications for budget alerts. Each list element should be a map with `protocol` and `endpoint` keys. More information about allowed values: https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html#API_Subscribe_RequestParameters"

--- a/terraform/budget/variables.tf
+++ b/terraform/budget/variables.tf
@@ -25,6 +25,6 @@ locals {
 }
 
 variable "warning_threshold_percents" {
-  default     = ["80", "90", "95"]
+  default     = ["80", "90", "95", "100"]
   description = "The percentages of budget used at which a warning is sent. Note that there is a limit on the total: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-limits.html#limits-reports"
 }

--- a/terraform/master/master.tf
+++ b/terraform/master/master.tf
@@ -21,6 +21,5 @@ resource "aws_organizations_policy_attachment" "tenants" {
 module "master_budget" {
   source = "../budget"
 
-  name         = "master"
-  budget_limit = "3000"
+  name = "master"
 }

--- a/terraform/master/tenant_tenant1.tf
+++ b/terraform/master/tenant_tenant1.tf
@@ -26,15 +26,10 @@ module "tenant_1_mgmt" {
   email = "jasong.miller+tenant1mgmt@gsa.gov"
 }
 
-data "aws_ssm_parameter" "tenant_1_budget" {
-  name = "tenant1-budget"
-}
-
 module "tenant_1_budget" {
   source = "../budget"
 
-  name         = "tenant1"
-  budget_limit = "${data.aws_ssm_parameter.tenant_1_budget.value}"
+  name = "tenant1"
 
   budget_notifications = [
     {

--- a/terraform/master/tenant_tenant1.tf
+++ b/terraform/master/tenant_tenant1.tf
@@ -26,13 +26,15 @@ module "tenant_1_mgmt" {
   email = "jasong.miller+tenant1mgmt@gsa.gov"
 }
 
+data "aws_ssm_parameter" "tenant_1_budget" {
+  name = "tenant1-budget"
+}
+
 module "tenant_1_budget" {
   source = "../budget"
 
-  name = "tenant1"
-
-  # arbitrary value
-  budget_limit = "100"
+  name         = "tenant1"
+  budget_limit = "${data.aws_ssm_parameter.tenant_1_budget.value}"
 
   budget_notifications = [
     {


### PR DESCRIPTION
https://trello.com/c/offU4CCt/526-as-everyone-who-isnt-aidan-i-want-the-budget-numbers-obfuscated

The budget limits were previously stored in the repository; this moves them to be stored in Parameter Store. I hadn't used it before - easy! Bonus that Parameter Store also maintains history. This move also has the advantage that modifying a budget no longer requires dealing with Terraform, Git, or GitHub, making it available to more members of the team (who are more likely to be dealing with budgets).

Very happy with how this turned out. I was worried the obfuscation would add a lot of complexity, but this pull request actually removes more lines of code than it adds! 😅 