### PR TITLE
Increase RequestThreshold to minimum of 2000

### DIFF
--- a/terraform/networking/variables.tf
+++ b/terraform/networking/variables.tf
@@ -79,17 +79,17 @@ variable "dev_customer_gateway_ip" {
 }
 
 variable "mgmt_access_log_bucket" {
-  default = "mgmt_alb_access_log"
+  default = "mgmt-waf-access-log"
 }
 
 variable "dev_access_log_bucket" {
-  default = "dev_alb_access_log"
+  default = "dev-waf-access-log"
 }
 
 variable "prod_access_log_bucket" {
-  default = "prod_alb_access_log"
+  default = "prod-waf-access-log"
 }
 
 variable "staging_access_log_bucket" {
-  default = "staging_alb_access_log"
+  default = "staging-waf-access-log"
 }

--- a/terraform/networking/waf-dev.tf
+++ b/terraform/networking/waf-dev.tf
@@ -22,7 +22,7 @@ resource "aws_cloudformation_stack" "dev_waf" {
     ActivateReputationListsProtectionParam = "yes"
     ActivateBadBotProtectionParam          = "yes"
     SendAnonymousUsageData                 = "no"
-    RequestThreshold                       = 200
+    RequestThreshold                       = 2000
     ErrorThreshold                         = 50
     WAFBlockPeriod                         = 240
   }

--- a/terraform/networking/waf-dev.tf
+++ b/terraform/networking/waf-dev.tf
@@ -22,7 +22,7 @@ resource "aws_cloudformation_stack" "dev_waf" {
     ActivateReputationListsProtectionParam = "yes"
     ActivateBadBotProtectionParam          = "yes"
     SendAnonymousUsageData                 = "no"
-    RequestThreshold                       = 400
+    RequestThreshold                       = 200
     ErrorThreshold                         = 50
     WAFBlockPeriod                         = 240
   }

--- a/terraform/networking/waf-mgmt.tf
+++ b/terraform/networking/waf-mgmt.tf
@@ -14,7 +14,7 @@ resource "aws_cloudformation_stack" "mgmt_waf" {
   provider = "aws.mgmt"
 
   parameters {
-    AccessLogBucket                        = "${aws_s3_bucket.dev_access_log_bucket.id}"
+    AccessLogBucket                        = "${aws_s3_bucket.mgmt_access_log_bucket.id}"
     SqlInjectionProtectionParam            = "yes"
     CrossSiteScriptingProtectionParam      = "yes"
     ActivateHttpFloodProtectionParam       = "yes"

--- a/terraform/networking/waf-mgmt.tf
+++ b/terraform/networking/waf-mgmt.tf
@@ -22,7 +22,7 @@ resource "aws_cloudformation_stack" "mgmt_waf" {
     ActivateReputationListsProtectionParam = "yes"
     ActivateBadBotProtectionParam          = "yes"
     SendAnonymousUsageData                 = "no"
-    RequestThreshold                       = 400
+    RequestThreshold                       = 2000
     ErrorThreshold                         = 50
     WAFBlockPeriod                         = 240
   }

--- a/terraform/networking/waf-prod.tf
+++ b/terraform/networking/waf-prod.tf
@@ -14,7 +14,7 @@ resource "aws_cloudformation_stack" "prod_waf" {
   provider = "aws.prod"
 
   parameters {
-    AccessLogBucket                        = "${aws_s3_bucket.dev_access_log_bucket.id}"
+    AccessLogBucket                        = "${aws_s3_bucket.prod_access_log_bucket.id}"
     SqlInjectionProtectionParam            = "yes"
     CrossSiteScriptingProtectionParam      = "yes"
     ActivateHttpFloodProtectionParam       = "yes"

--- a/terraform/networking/waf-prod.tf
+++ b/terraform/networking/waf-prod.tf
@@ -22,7 +22,7 @@ resource "aws_cloudformation_stack" "prod_waf" {
     ActivateReputationListsProtectionParam = "yes"
     ActivateBadBotProtectionParam          = "yes"
     SendAnonymousUsageData                 = "no"
-    RequestThreshold                       = 400
+    RequestThreshold                       = 2000
     ErrorThreshold                         = 50
     WAFBlockPeriod                         = 240
   }

--- a/terraform/networking/waf-staging.tf
+++ b/terraform/networking/waf-staging.tf
@@ -22,7 +22,7 @@ resource "aws_cloudformation_stack" "staging_waf" {
     ActivateReputationListsProtectionParam = "yes"
     ActivateBadBotProtectionParam          = "yes"
     SendAnonymousUsageData                 = "no"
-    RequestThreshold                       = 400
+    RequestThreshold                       = 2000
     ErrorThreshold                         = 50
     WAFBlockPeriod                         = 240
   }

--- a/terraform/networking/waf-staging.tf
+++ b/terraform/networking/waf-staging.tf
@@ -14,7 +14,7 @@ resource "aws_cloudformation_stack" "staging_waf" {
   provider = "aws.staging"
 
   parameters {
-    AccessLogBucket                        = "${aws_s3_bucket.dev_access_log_bucket.id}"
+    AccessLogBucket                        = "${aws_s3_bucket.staging_access_log_bucket.id}"
     SqlInjectionProtectionParam            = "yes"
     CrossSiteScriptingProtectionParam      = "yes"
     ActivateHttpFloodProtectionParam       = "yes"


### PR DESCRIPTION
Increases RequestThreshold to 2000 since new WAF CloudFormation code from AWS requires that as the minimum.