### PR TITLE
support an arbitrary number of subnets associated with the VPN

### DIFF
--- a/terraform/networking/vpc-env.tf
+++ b/terraform/networking/vpc-env.tf
@@ -27,7 +27,8 @@ module "env_spoke" {
     aws = "aws.env"
   }
 
-  gateway_subnet_ids = "${module.vpc_env.private_subnets}"
+  num_gateway_subnets = "2"
+  gateway_subnet_ids  = "${module.vpc_env.private_subnets}"
 }
 
 resource "aws_vpc_peering_connection" "peer_vpc_env" {

--- a/terraform/networking/vpc-env.tf
+++ b/terraform/networking/vpc-env.tf
@@ -27,7 +27,7 @@ module "env_spoke" {
     aws = "aws.env"
   }
 
-  gateway_subnet_id = "${module.vpc_env.private_subnets[0]}"
+  gateway_subnet_ids = "${module.vpc_env.private_subnets}"
 }
 
 resource "aws_vpc_peering_connection" "peer_vpc_env" {

--- a/terraform/networking/vpc-mgmt.tf
+++ b/terraform/networking/vpc-mgmt.tf
@@ -28,7 +28,7 @@ module "mgmt_spoke" {
     aws = "aws.mgmt"
   }
 
-  gateway_subnet_id = "${module.vpc_mgmt.private_subnets[0]}"
+  gateway_subnet_ids = "${module.vpc_mgmt.private_subnets}"
 }
 
 # The accepter resources below are commented out because currently, these VPCs are all in the same account. If the VPC's are in separate accounts, then enable these resources and look at the peer connections in the other files to make sure they are set to auto_accept = false.

--- a/terraform/networking/vpc-mgmt.tf
+++ b/terraform/networking/vpc-mgmt.tf
@@ -28,7 +28,8 @@ module "mgmt_spoke" {
     aws = "aws.mgmt"
   }
 
-  gateway_subnet_ids = "${module.vpc_mgmt.private_subnets}"
+  num_gateway_subnets = "2"
+  gateway_subnet_ids  = "${module.vpc_mgmt.private_subnets}"
 }
 
 # The accepter resources below are commented out because currently, these VPCs are all in the same account. If the VPC's are in separate accounts, then enable these resources and look at the peer connections in the other files to make sure they are set to auto_accept = false.

--- a/terraform/spoke/main.tf
+++ b/terraform/spoke/main.tf
@@ -1,5 +1,5 @@
 data "aws_subnet" "selected" {
-  id = "${var.gateway_subnet_id}"
+  id = "${var.gateway_subnet_ids[0]}"
 }
 
 resource "aws_route_table" "Priv-Route" {
@@ -12,7 +12,9 @@ resource "aws_route_table" "Priv-Route" {
 }
 
 resource "aws_route_table_association" "route_asso" {
-  subnet_id      = "${var.gateway_subnet_id}"
+  count = "${length(var.gateway_subnet_ids)}"
+
+  subnet_id      = "${var.gateway_subnet_ids[count.index]}"
   route_table_id = "${aws_route_table.Priv-Route.id}"
 }
 

--- a/terraform/spoke/main.tf
+++ b/terraform/spoke/main.tf
@@ -11,8 +11,27 @@ resource "aws_route_table" "Priv-Route" {
   }
 }
 
+# Verify that the count matches the list
+# https://github.com/hashicorp/terraform/issues/10857#issuecomment-368059147
+resource "null_resource" "verify_list_count" {
+  provisioner "local-exec" {
+    command = <<SH
+if [ ${var.num_gateway_subnets} -ne ${length(var.gateway_subnet_ids)} ]; then
+  echo "var.num_gateway_subnets must match the actual length of var.gateway_subnet_ids";
+  exit 1;
+fi
+SH
+  }
+
+  # Rerun this script, if the input values change
+  triggers {
+    num_gateway_subnets_computed = "${length(var.gateway_subnet_ids)}"
+    num_gateway_subnets_provided = "${var.num_gateway_subnets}"
+  }
+}
+
 resource "aws_route_table_association" "route_asso" {
-  count = "${length(var.gateway_subnet_ids)}"
+  count = "${var.num_gateway_subnets}"
 
   subnet_id      = "${var.gateway_subnet_ids[count.index]}"
   route_table_id = "${aws_route_table.Priv-Route.id}"

--- a/terraform/spoke/main.tf
+++ b/terraform/spoke/main.tf
@@ -2,41 +2,6 @@ data "aws_subnet" "selected" {
   id = "${var.gateway_subnet_ids[0]}"
 }
 
-resource "aws_route_table" "Priv-Route" {
-  vpc_id           = "${data.aws_subnet.selected.vpc_id}"
-  propagating_vgws = ["${aws_vpn_gateway.Transit-Spoke-VGW.id}"]
-
-  tags {
-    Name = "Priv-Route"
-  }
-}
-
-# Verify that the count matches the list
-# https://github.com/hashicorp/terraform/issues/10857#issuecomment-368059147
-resource "null_resource" "verify_list_count" {
-  provisioner "local-exec" {
-    command = <<SH
-if [ ${var.num_gateway_subnets} -ne ${length(var.gateway_subnet_ids)} ]; then
-  echo "var.num_gateway_subnets must match the actual length of var.gateway_subnet_ids";
-  exit 1;
-fi
-SH
-  }
-
-  # Rerun this script, if the input values change
-  triggers {
-    num_gateway_subnets_computed = "${length(var.gateway_subnet_ids)}"
-    num_gateway_subnets_provided = "${var.num_gateway_subnets}"
-  }
-}
-
-resource "aws_route_table_association" "route_asso" {
-  count = "${var.num_gateway_subnets}"
-
-  subnet_id      = "${var.gateway_subnet_ids[count.index]}"
-  route_table_id = "${aws_route_table.Priv-Route.id}"
-}
-
 resource "aws_vpn_gateway" "Transit-Spoke-VGW" {
   vpc_id = "${data.aws_subnet.selected.vpc_id}"
 

--- a/terraform/spoke/route_table.tf
+++ b/terraform/spoke/route_table.tf
@@ -1,0 +1,34 @@
+resource "aws_route_table" "Priv-Route" {
+  vpc_id           = "${data.aws_subnet.selected.vpc_id}"
+  propagating_vgws = ["${aws_vpn_gateway.Transit-Spoke-VGW.id}"]
+
+  tags {
+    Name = "Priv-Route"
+  }
+}
+
+# Verify that the count matches the list
+# https://github.com/hashicorp/terraform/issues/10857#issuecomment-368059147
+resource "null_resource" "verify_list_count" {
+  provisioner "local-exec" {
+    command = <<SH
+if [ ${var.num_gateway_subnets} -ne ${length(var.gateway_subnet_ids)} ]; then
+  echo "var.num_gateway_subnets must match the actual length of var.gateway_subnet_ids";
+  exit 1;
+fi
+SH
+  }
+
+  # Rerun this script, if the input values change
+  triggers {
+    num_gateway_subnets_computed = "${length(var.gateway_subnet_ids)}"
+    num_gateway_subnets_provided = "${var.num_gateway_subnets}"
+  }
+}
+
+resource "aws_route_table_association" "route_asso" {
+  count = "${var.num_gateway_subnets}"
+
+  subnet_id      = "${var.gateway_subnet_ids[count.index]}"
+  route_table_id = "${aws_route_table.Priv-Route.id}"
+}

--- a/terraform/spoke/variables.tf
+++ b/terraform/spoke/variables.tf
@@ -1,6 +1,6 @@
 variable "num_gateway_subnets" {
   type        = "string"
-  description = "The number of gatway_subnet_ids. Workaround for https://github.com/hashicorp/terraform/issues/10857."
+  description = "The number of gaetway_subnet_ids. Workaround for https://github.com/hashicorp/terraform/issues/10857."
 }
 
 variable "gateway_subnet_ids" {

--- a/terraform/spoke/variables.tf
+++ b/terraform/spoke/variables.tf
@@ -1,3 +1,8 @@
+variable "num_gateway_subnets" {
+  type        = "string"
+  description = "The number of gatway_subnet_ids. Workaround for https://github.com/hashicorp/terraform/issues/10857."
+}
+
 variable "gateway_subnet_ids" {
   type        = "list"
   description = "IDs of subnets to attach the route table to. Must all be in the same VPC."

--- a/terraform/spoke/variables.tf
+++ b/terraform/spoke/variables.tf
@@ -1,5 +1,6 @@
-variable "gateway_subnet_id" {
-  type = "string"
+variable "gateway_subnet_ids" {
+  type        = "list"
+  description = "IDs of subnets to attach the route table to. Must all be in the same VPC."
 }
 
 variable "TransitVpcBucketName" {

--- a/terraform/spoke/variables.tf
+++ b/terraform/spoke/variables.tf
@@ -1,6 +1,6 @@
 variable "num_gateway_subnets" {
   type        = "string"
-  description = "The number of gaetway_subnet_ids. Workaround for https://github.com/hashicorp/terraform/issues/10857."
+  description = "The number of gateway_subnet_ids. Workaround for https://github.com/hashicorp/terraform/issues/10857."
 }
 
 variable "gateway_subnet_ids" {


### PR DESCRIPTION
This pull request adds support for directing spoke VPN traffic to multiple subnets. I am not super familiar with route tables, so please confirm that this is reasonable.