### PR TITLE
remove peering connection from networking example

### DIFF
--- a/terraform/networking/README.md
+++ b/terraform/networking/README.md
@@ -1,8 +1,8 @@
 # Tenant networking
 
-This repo is a test implementation of the GSA DevSecOps tenant networking model. The model is intended to be used across 4 different AWS accounts. However, while that is being worked out, this repo deploys into 1 AWS account but across 3 different regions.
+This repo is a test implementation of the GSA DevSecOps tenant networking model. The model is intended to be used across different AWS accounts. However, while that is being worked out, this repo deploys into 1 AWS account but across different regions.
 
-The repo deploys 2 VPCs: management, and an environment. Each VPC is in the same region because of a peering issue between us-west-1 and us-east-2. It will deploy the necessary VPN gateways and peering connections. The environment VPC will be peered with the Management VPC. Both VPCs will be set up with a VPN connection to the shared transit VPC.
+The repo deploys 2 VPCs: management, and an environment, with the necessary gateways. Both VPCs will be set up with a VPN connection to the shared transit VPC.
 
 The Cloud Formation template for the AWS Web Application Firewall (WAF) was
 downloaded from [here](https://s3.amazonaws.com/solutions-reference/aws-waf-security-automations/latest/aws-waf-security-automations-alb.template).

--- a/terraform/networking/aws.tf
+++ b/terraform/networking/aws.tf
@@ -19,15 +19,3 @@ provider "aws" {
   #   role_arn = "arn:aws:iam::${var.mgmt_account_id}:role/${var.iam_role_name}"
   # }
 }
-
-data "aws_caller_identity" "default" {
-  provider = "aws"
-}
-
-data "aws_caller_identity" "env" {
-  provider = "aws.env"
-}
-
-data "aws_caller_identity" "mgmt" {
-  provider = "aws.mgmt"
-}

--- a/terraform/networking/vpc-env.tf
+++ b/terraform/networking/vpc-env.tf
@@ -30,32 +30,6 @@ module "env_spoke" {
   vpc_id = "${module.vpc_env.vpc_id}"
 }
 
-resource "aws_vpc_peering_connection" "peer_vpc_env" {
-  vpc_id      = "${module.vpc_env.vpc_id}"
-  peer_vpc_id = "${module.vpc_mgmt.vpc_id}"
-  peer_region = "${var.mgmt_region}"
-
-  # Because the VPCs are currently in the same account, will set auto_accept to true. When VPC's are in separate accounts, uncomment the next two lines.
-  peer_owner_id = "${data.aws_caller_identity.mgmt.account_id}"
-  auto_accept   = false
-
-  # auto_accept   = true
-  provider = "aws.env"
-
-  # accepter {
-  #   allow_remote_vpc_dns_resolution = true
-  # }
-
-
-  # requester {
-  #   allow_remote_vpc_dns_resolution = true
-  # }
-
-  tags {
-    Side = "Requester"
-  }
-}
-
 # Optional Base Security Groups
 resource "aws_security_group" "env_ingress_https_sg" {
   # Conditionally create this resource if the value is true

--- a/terraform/networking/vpc-mgmt.tf
+++ b/terraform/networking/vpc-mgmt.tf
@@ -31,18 +31,6 @@ module "mgmt_spoke" {
   vpc_id = "${module.vpc_mgmt.vpc_id}"
 }
 
-# The accepter resources below are commented out because currently, these VPCs are all in the same account. If the VPC's are in separate accounts, then enable these resources and look at the peer connections in the other files to make sure they are set to auto_accept = false.
-#
-
-resource "aws_vpc_peering_connection_accepter" "peer_vpc_env" {
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer_vpc_env.id}"
-  auto_accept               = true
-
-  tags {
-    Side = "Accepter for the environment"
-  }
-}
-
 # TODO: Add conditional with default of true for this
 resource "aws_security_group" "mgmt_ec2_management_sg" {
   # Conditionally create this resource if value is true


### PR DESCRIPTION
https://trello.com/c/GCc8EEaH/539-remove-peering-from-networking-example

We are no longer doing peering - all traffic will go through the Transit VPC.