### PR TITLE
Parameter store encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ After the paperwork is done:
 The users are managed by SSM Parameter Store objects. You will want to create the parameter store objects in the authlanding account after it is created. Using the web console is recommended, as this part can get confusing.
 
 1. Switch to the authlanding account in the AWS web console, using an IAM role or account that has permissions to add/modify parameter store objects.
+1. Note that the authlanding tenant Terraform has a KMS key. You can use this key or create one manually in the IAM encryption keys console. This key will be used to encrypt the parameters.
 1. Go to the EC2 SSM Parameter Store page.
-1. Create a parameter store object called "authlanding-user-list". Use the list type "StringList" and type the list of usernames, delimited by commas. Do not use spaces. These users should follow a naming scheme. But the usernames must be unique.
+1. Create a parameter store object called "authlanding-user-list". Use the list type "SecureString" and choose the key you wish to use for encryption. Type the list of usernames, delimited by commas. Do not use spaces. These users should follow a naming scheme. But the usernames must be unique.
 1. Apply the terraform in the master directory. This will create the user objects from the list you provided. You *must* manually [activate MFA inside the web console](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html) for the users the first time they are created.
 1. Next, create the tenant-specific parameter objects that describe the groups. For example, tenant 1 has three parameter store objects: "tenant-1-admin-iam-role-list", "tenant-1-poweruser-iam-role-list" and "tenant-1-viewonly-iam-role-list". Look in the file "tenant_tenant1.tf" to see how these parameters are used.
 1. Create the parameter store objects with these names. Make them a type of StringList and use a comma-delimited set of SNA usernames. Note that the users MUST ALREADY EXIST before you add them to these groups, or AWS and Terraform will fail to create or update the IAM roles for the tenant account.

--- a/terraform/master/authlanding_account.tf
+++ b/terraform/master/authlanding_account.tf
@@ -47,6 +47,7 @@ provider "aws" {
 #
 # Create a KMS key to manage the parameter stores. This key must be used in the web console when creating parameters in authlanding.
 resource "aws_kms_key" "users_parameter_stores_kms_key" {
+  provider                = "aws.authlanding"
   description             = "KMS key to encrypt and decrypt parameter store objects for user management. Required by security, managed by Terraform in grace-core."
   deletion_window_in_days = 30
   enable_key_rotation     = "true"

--- a/terraform/master/authlanding_account.tf
+++ b/terraform/master/authlanding_account.tf
@@ -44,6 +44,14 @@ provider "aws" {
 }
 
 ### USER MANAGEMENT
+#
+# Create a KMS key to manage the parameter stores. This key must be used in the web console when creating parameters in authlanding.
+resource "aws_kms_key" "users_parameter_stores_kms_key" {
+  description             = "KMS key to encrypt and decrypt parameter store objects for user management. Required by security, managed by Terraform in grace-core."
+  deletion_window_in_days = 30
+  enable_key_rotation     = "true"
+}
+
 # This SSM Parameter Store will contain a comma-delimited list of users that will be created with the resource below.
 data "aws_ssm_parameter" "authlanding_user_list" {
   provider = "aws.authlanding"

--- a/terraform/master/tenant_tenant1.tf
+++ b/terraform/master/tenant_tenant1.tf
@@ -33,7 +33,6 @@ module "tenant_1_prod" {
   authlanding_prod_account_id = "${module.authlanding_prod.account_id}"
   create_iam_roles            = "true"
 
-  # TODO: Add lists of IAM role memberships
   tenant_admin_iam_role_list     = ["${local.tenant_admin_iam_role_list}"]
   tenant_poweruser_iam_role_list = ["${local.tenant_poweruser_iam_role_list}"]
   tenant_viewonly_iam_role_list  = ["${local.tenant_viewonly_iam_role_list}"]
@@ -47,7 +46,6 @@ module "tenant_1_staging" {
   authlanding_prod_account_id = "${module.authlanding_prod.account_id}"
   create_iam_roles            = "true"
 
-  # TODO: Add lists of IAM role memberships
   tenant_admin_iam_role_list     = ["${local.tenant_admin_iam_role_list}"]
   tenant_poweruser_iam_role_list = ["${local.tenant_poweruser_iam_role_list}"]
   tenant_viewonly_iam_role_list  = ["${local.tenant_viewonly_iam_role_list}"]
@@ -61,7 +59,6 @@ module "tenant_1_dev" {
   authlanding_prod_account_id = "${module.authlanding_prod.account_id}"
   create_iam_roles            = "true"
 
-  # TODO: Add lists of IAM role memberships
   tenant_admin_iam_role_list     = ["${local.tenant_admin_iam_role_list}"]
   tenant_poweruser_iam_role_list = ["${local.tenant_poweruser_iam_role_list}"]
   tenant_viewonly_iam_role_list  = ["${local.tenant_viewonly_iam_role_list}"]
@@ -75,7 +72,6 @@ module "tenant_1_mgmt" {
   authlanding_prod_account_id = "${module.authlanding_prod.account_id}"
   create_iam_roles            = "true"
 
-  # TODO: Add lists of IAM role memberships
   tenant_admin_iam_role_list     = ["${local.tenant_admin_iam_role_list}"]
   tenant_poweruser_iam_role_list = ["${local.tenant_poweruser_iam_role_list}"]
   tenant_viewonly_iam_role_list  = ["${local.tenant_viewonly_iam_role_list}"]


### PR DESCRIPTION
Adds a KMS key. Fortunately, it's that easy. Just use that key to encrypt the parameters and Terraform handles them natively. Cool.