### PR TITLE
Add readonly policy on existing SecOpsAdmin Role

### DIFF
--- a/terraform/member_account/secops_iam_policies.tf
+++ b/terraform/member_account/secops_iam_policies.tf
@@ -29,6 +29,15 @@ resource "aws_iam_role_policy_attachment" "grace_secops_admins_policy_attachment
   policy_arn = "${aws_iam_policy.GRACE_SecOps_Admins_Policy.arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "grace_secops_admins_policy_attachment-1" {
+  count = "${var.create_iam_roles == "true" ? 1 : 0}"
+
+  provider = "aws.child"
+
+  role       = "${aws_iam_role.secops_admin_role.name}"
+  policy_arn = "${aws_iam_policy.GRACE_SecOps_View_Only_Policy.arn}"
+}
+
 resource "aws_iam_role_policy_attachment" "grace_secops_view_only_policy_attachment" {
   count = "${var.create_iam_roles == "true" ? 1 : 0}"
 


### PR DESCRIPTION
Stacking readonly policy on top of existing custom policy on SecopsAdmin role. Some services like ec2 are not visible right now. 