### PR TITLE
Resolves KMS Key creation issue (malformed policy)

### DIFF
--- a/terraform/master/files/tenant-info-bucket-kms-key-policy.json
+++ b/terraform/master/files/tenant-info-bucket-kms-key-policy.json
@@ -3,6 +3,28 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "Allow administration of the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "${packer_builder_user_arn}"
+            },
+            "Action": [
+                "kms:Create*",
+                "kms:Describe*",
+                "kms:Enable*",
+                "kms:List*",
+                "kms:Put*",
+                "kms:Update*",
+                "kms:Revoke*",
+                "kms:Disable*",
+                "kms:Get*",
+                "kms:Delete*",
+                "kms:ScheduleKeyDeletion",
+                "kms:CancelKeyDeletion"
+            ],
+            "Resource": "*"
+        },
+        {
             "Sid": "Stmt0813201801",
             "Action": [
                 "kms:Encrypt",

--- a/terraform/master/platform_gracesharedservices.tf
+++ b/terraform/master/platform_gracesharedservices.tf
@@ -327,6 +327,7 @@ data "template_file" "tenant_info_bucket_kms_key_policy" {
     vars = {
       shared_services_prod_account_id = "${module.tenant_gracesharedservices_prod.account_id}"
       shared_services_mgmt_account_id = "${module.tenant_gracesharedservices_mgmt.account_id}"
+      packer_builder_user_arn = "${aws_iam_user.packer_builder.arn}"
       tenant_account_lister_role_arn = "${aws_iam_role.tenant_account_lister_role.arn}"
   }
 }


### PR DESCRIPTION
AWS API wouldn't allow my KMS key to be created because there was no user specified as an owner of the key. This adds to the policy to allow the packer_builder user "own" the key.